### PR TITLE
Add ntp playbook.

### DIFF
--- a/ansible/roles/ntp/handlers/main.yml
+++ b/ansible/roles/ntp/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart ntp
+  service: name=ntp state=restarted

--- a/ansible/roles/ntp/tasks/main.yml
+++ b/ansible/roles/ntp/tasks/main.yml
@@ -1,0 +1,25 @@
+- lineinfile:
+    path: /etc/ntp.conf 
+    regexp: "server 0.debian.pool.ntp.org iburst"
+    line: "#server 0.debian.pool.ntp.org iburst"
+  notify: restart ntp
+- lineinfile:
+    path: /etc/ntp.conf 
+    regexp: "server 1.debian.pool.ntp.org iburst"
+    line: "#server 1.debian.pool.ntp.org iburst"
+  notify: restart ntp
+- lineinfile:
+    path: /etc/ntp.conf 
+    regexp: "server 2.debian.pool.ntp.org iburst"
+    line: "#server 2.debian.pool.ntp.org iburst"
+  notify: restart ntp
+- lineinfile:
+    path: /etc/ntp.conf 
+    regexp: "server 3.debian.pool.ntp.org iburst"
+    line: "#server 3.debian.pool.ntp.org iburst"
+  notify: restart ntp
+- lineinfile: 
+    path: /etc/ntp.conf 
+    insertafter: '^#server 3.debian.pool.ntp.org iburst'
+    line: "pool ntp.nict.jp iburst"
+  notify: restart ntp

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -2,6 +2,7 @@
   hosts: all
   become: yes
   roles:
+    - ntp
     - timezone
     - git
     - zabbix-agent


### PR DESCRIPTION
Update /etc/ntp.conf

*before)*
```
server 0.debian.pool.ntp.org iburst
server 1.debian.pool.ntp.org iburst
server 2.debian.pool.ntp.org iburst
server 3.debian.pool.ntp.org iburst
```

*after)*
```
#server 0.debian.pool.ntp.org iburst
#server 1.debian.pool.ntp.org iburst
#server 2.debian.pool.ntp.org iburst
#server 3.debian.pool.ntp.org iburst
pool ntp.nict.jp iburst
```

Enable ntp.nict.jp.
```
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*ntp-a3.nict.go. .NICT.           1 u   65   64  177   21.693   -0.223   0.389
+ntp-b3.nict.go. .NICT.           1 u   68   64  177   22.811   -0.428   0.904
+ntp-b2.nict.go. .NICT.           1 u   66   64  177   22.066   -0.350   0.390
+ntp-a2.nict.go. .NICT.           1 u   64   64  177   22.328   -0.026   0.860
 ntp-a3.nict.go. .INIT.          16 -    -   64    0    0.000    0.000   0.000
 ntp-a2.nict.go. .INIT.          16 -    -   64    0    0.000    0.000   0.000
```