### PR TITLE
Move cron to systemctl mon interface startup script.

### DIFF
--- a/ansible/roles/mon-if/files/etc/systemd/system/mon-if.service
+++ b/ansible/roles/mon-if/files/etc/systemd/system/mon-if.service
@@ -1,0 +1,10 @@
+[Unit]
+Description = monitoring interface up
+After=network.target
+
+[Service]
+ExecStart=/srv/mon-if/mon-if.sh
+Type=oneshot
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/mon-if/handlers/main.yml
+++ b/ansible/roles/mon-if/handlers/main.yml
@@ -1,2 +1,5 @@
-- name: exec mon-if
-  command: /srv/mon-if/mon-if.sh
+- name: mon-if up
+  systemd:
+    name: mon-if
+    state: restarted 
+    daemon_reload: yes

--- a/ansible/roles/mon-if/tasks/main.yml
+++ b/ansible/roles/mon-if/tasks/main.yml
@@ -1,5 +1,23 @@
-- file: path=/srv/mon-if state=directory owner=root group=root mode=0755
-- copy: src=srv/mon-if/mon-if.sh dest=/srv/mon-if/mon-if.sh owner=root group=root mode=0700
+- file: 
+    path: /srv/mon-if
+    state: directory
+    owner: root
+    group: root
+    mode: 0755
+- copy: 
+    src: srv/mon-if/mon-if.sh
+    dest: /srv/mon-if/mon-if.sh
+    owner: root
+    group: root
+    mode: 0700
   notify: mon-if up
-- copy: src=etc/systemd/system/mon-if.service dest=/etc/systemd/system/mon-if.service owner=root group=root mode=0644
+- copy: 
+    src: etc/systemd/system/mon-if.service 
+    dest: /etc/systemd/system/mon-if.service 
+    owner: root 
+    group: root 
+    mode: 0644
   notify: mon-if up
+- systemd: 
+    name: mon-if 
+    enabled: yes

--- a/ansible/roles/mon-if/tasks/main.yml
+++ b/ansible/roles/mon-if/tasks/main.yml
@@ -1,4 +1,5 @@
 - file: path=/srv/mon-if state=directory owner=root group=root mode=0755
 - copy: src=srv/mon-if/mon-if.sh dest=/srv/mon-if/mon-if.sh owner=root group=root mode=0700
-  notify: exec mon-if
-- cron: name="Set mon0 interface." special_time=reboot job="/srv/mon-if/mon-if.sh" 
+  notify: mon-if up
+- copy: src=etc/systemd/system/mon-if.service dest=/etc/systemd/system/mon-if.service owner=root group=root mode=0644
+  notify: mon-if up


### PR DESCRIPTION
Remove crontab.
Add system file.

```
$ sudo systemctl status mon-if
● mon-if.service - monitoring interface up
   Loaded: loaded (/etc/systemd/system/mon-if.service; enabled)
   Active: inactive (dead) since Mon 2017-05-15 18:14:50 JST; 15min ago
  Process: 763 ExecStart=/srv/mon-if/mon-if.sh (code=exited, status=0/SUCCESS)
 Main PID: 763 (code=exited, status=0/SUCCESS)

May 15 18:14:50 my-test mon-if.sh[763]: command failed: No such file or directory (-2)
May 15 18:14:50 my-test mon-if.sh[763]: command failed: No such file or directory (-2)
May 15 18:14:50 my-test mon-if.sh[763]: command failed: No such file or directory (-2)
May 15 18:14:50 my-test systemd[1]: Started monitoring interface up.
```