### PR TITLE
Add zabbix server ip for /etc/hosts.

### DIFF
--- a/ansible/group_vars/all.example
+++ b/ansible/group_vars/all.example
@@ -1,5 +1,6 @@
 zabbix_agent:
-  server: "MY ZABBIX SERVER"
+  server_hostname: "MY ZABBIX SERVER"
+	server_ip_address: "MY ZABBIX SERVER IP"
 pyyaml:
   version: 3.11
 requests:

--- a/ansible/roles/zabbix-agent/tasks/main.yml
+++ b/ansible/roles/zabbix-agent/tasks/main.yml
@@ -1,9 +1,27 @@
-- apt: name=zabbix-agent
-- lineinfile: dest=/etc/zabbix/zabbix_agentd.conf regexp="^Server=" line="Server={{ zabbix_agent.server }}"
+- apt:
+    name: zabbix-agent
+- lineinfile:
+    dest: /etc/zabbix/zabbix_agentd.conf
+    regexp: "^Server="
+    line: "Server={{ zabbix_agent.server_hostname }}"
   notify: restart zabbix-agent
-- lineinfile: dest=/etc/zabbix/zabbix_agentd.conf regexp="^ServerActive" line="ServerActive={{ zabbix_agent.server }}"
+- lineinfile:
+    dest: /etc/zabbix/zabbix_agentd.conf
+    regexp: "^ServerActive"
+    line: "ServerActive={{ zabbix_agent.server_hostname }}"
   notify: restart zabbix-agent
-- lineinfile: dest=/etc/zabbix/zabbix_agentd.conf regexp="^Hostname=" line="Hostname={{ ansible_hostname }}"
+- lineinfile:
+    dest: /etc/zabbix/zabbix_agentd.conf
+    regexp: "^Hostname="
+    line: "Hostname={{ ansible_hostname }}"
   notify: restart zabbix-agent
-- lineinfile: dest=/etc/zabbix/zabbix_agentd.conf regexp="^HostnameItem=" line="HostnameItem={{ ansible_hostname }}"
+- lineinfile:
+    dest: /etc/zabbix/zabbix_agentd.conf
+    regexp: "^HostnameItem="
+    line: "HostnameItem={{ ansible_hostname }}"
+  notify: restart zabbix-agent
+- lineinfile:
+    dest: /etc/hosts
+    regexp: "{{ zabbix_agent.server_hostname }}$"
+    line: "{{ zabbix_agent.server_ip_address }}\t{{ zabbix_agent.server_hostname }}"
   notify: restart zabbix-agent

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -5,12 +5,12 @@
     - ntp
     - timezone
     - git
-    - zabbix-agent
     - tshark
     - python-pip
     - pyyaml
     - requests
     - mon-if
     - capture
+    - { role: zabbix-agent, tags: [ 'zabbix-agent' ] }
     - { role: post_data, tags: [ 'post_data' ] }
     - { role: static_ip, tags: [ 'static_ip' ] }


### PR DESCRIPTION
Run zabbix-agent on raspi, can't find zabbix server now.
So add zabbix server ip address for /etc/hosts file.

And release ...
- Add zabbix-agent tag for zabbix-agent role. Because want run only zabbix-agent playbook.
- Refactor zabbix-agent/tasks/main.yml file.
- Replace variable zabbix-agent.server -> zabbix-agent.server_hostname.