### PR TITLE
Add zabbix item get mac address.

### DIFF
--- a/ansible/roles/zabbix-agent/files/etc/zabbix/zabbix_agentd.conf.d/get_mac_addr.conf
+++ b/ansible/roles/zabbix-agent/files/etc/zabbix/zabbix_agentd.conf.d/get_mac_addr.conf
@@ -1,0 +1,1 @@
+UserParameter=gn.mac[*],ifconfig $1 | grep HWaddr | awk '{ print $$5 }'

--- a/ansible/roles/zabbix-agent/tasks/main.yml
+++ b/ansible/roles/zabbix-agent/tasks/main.yml
@@ -25,3 +25,10 @@
     regexp: "{{ zabbix_agent.server_hostname }}$"
     line: "{{ zabbix_agent.server_ip_address }}\t{{ zabbix_agent.server_hostname }}"
   notify: restart zabbix-agent
+- copy:
+    src: etc/zabbix/zabbix_agentd.conf.d/
+    dest: /etc/zabbix/zabbix_agentd.conf.d/
+    owner: zabbix
+    group: zabbix
+    mode: 0644
+  notify: restart zabbix-agent


### PR DESCRIPTION
Check MAC Address, on zabbix dash board.

# test
Exec zabbix server.
```
$ zabbix_get -s <RASPI> -k gn.mac[eth0]
aa:bb:cc:dd:ee:ff
```