### PR TITLE
Add tool to run BigQuery queries to generate training data.

### DIFF
--- a/scripts/generate_training_data/.gitignore
+++ b/scripts/generate_training_data/.gitignore
@@ -1,0 +1,3 @@
+/.bundle
+/vendor/bundle
+/config*.yml

--- a/scripts/generate_training_data/Gemfile
+++ b/scripts/generate_training_data/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "kura"

--- a/scripts/generate_training_data/Gemfile.lock
+++ b/scripts/generate_training_data/Gemfile.lock
@@ -1,0 +1,63 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.1)
+      public_suffix (~> 2.0, >= 2.0.2)
+    declarative (0.0.9)
+    declarative-option (0.1.0)
+    faraday (0.12.1)
+      multipart-post (>= 1.2, < 3)
+    google-api-client (0.10.3)
+      addressable (~> 2.3)
+      googleauth (~> 0.5)
+      httpclient (~> 2.7)
+      hurley (~> 0.1)
+      memoist (~> 0.11)
+      mime-types (>= 1.6)
+      representable (~> 3.0)
+      retriable (>= 2.0, < 4.0)
+    googleauth (0.5.1)
+      faraday (~> 0.9)
+      jwt (~> 1.4)
+      logging (~> 2.0)
+      memoist (~> 0.12)
+      multi_json (~> 1.11)
+      os (~> 0.9)
+      signet (~> 0.7)
+    httpclient (2.8.3)
+    hurley (0.2)
+    jwt (1.5.6)
+    kura (0.2.26)
+      google-api-client (>= 0.9.11, < 0.11.0)
+    little-plugger (1.1.4)
+    logging (2.2.2)
+      little-plugger (~> 1.1)
+      multi_json (~> 1.10)
+    memoist (0.15.0)
+    mime-types (3.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2016.0521)
+    multi_json (1.12.1)
+    multipart-post (2.0.0)
+    os (0.9.6)
+    public_suffix (2.0.5)
+    representable (3.0.4)
+      declarative (< 0.1.0)
+      declarative-option (< 0.2.0)
+      uber (< 0.2.0)
+    retriable (3.0.2)
+    signet (0.7.3)
+      addressable (~> 2.3)
+      faraday (~> 0.9)
+      jwt (~> 1.5)
+      multi_json (~> 1.10)
+    uber (0.1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  kura
+
+BUNDLED WITH
+   1.14.6

--- a/scripts/generate_training_data/README.md
+++ b/scripts/generate_training_data/README.md
@@ -1,0 +1,10 @@
+# Create Training Data
+
+This tool run BigQuery queries to create training data from `wifi_data` and `wifi_measurement_time` tables.
+
+## How to use.
+1. `cd scripts/generate_training_data`
+2. `bundle install --path vendor/bundle`
+3. Create config.yml and store monitoring device's MAC addresses. See config.yml.example for reference.
+3. `bundle exec ruby create_measurement_data.rb --dataset=DATASET_ID`
+

--- a/scripts/generate_training_data/config.yml.example
+++ b/scripts/generate_training_data/config.yml.example
@@ -1,0 +1,5 @@
+mac_addresses:
+  - "XX:XX:XX:00:00:01"
+  - "XX:XX:XX:00:00:02"
+  - "XX:XX:XX:00:00:03"
+  - "XX:XX:XX:00:00:04"

--- a/scripts/generate_training_data/create_measurement_data.rb
+++ b/scripts/generate_training_data/create_measurement_data.rb
@@ -18,7 +18,11 @@ OptionParser.new do |opt|
     confing[:interval] = int
   end
   opt.parse!
-  config_file, = ARGV
+  if ARGV[0]
+    config_file = ARGV[0]
+  else
+    config_file = "./config.yml"
+  end
   d = YAML.load(File.read(config_file))
   config[:mac_addresses] = d["mac_addresses"]
 end

--- a/scripts/generate_training_data/create_measurement_data.rb
+++ b/scripts/generate_training_data/create_measurement_data.rb
@@ -1,0 +1,91 @@
+
+require "optparse"
+require "yaml"
+require "kura"
+
+config = {
+  project_id: "blocks-next-2017",
+  interval: 10,
+}
+OptionParser.new do |opt|
+  opt.on("--project PROJECT_ID", "specify GCP project id") do |str|
+    config[:project_id] = str
+  end
+  opt.on("--dataset DATASET", "specify BigQuery Dataset ID") do |str|
+    config[:dataset] = str
+  end
+  opt.on("--interval INTERVAL", "specify interval in seconds", Integer) do |int|
+    confing[:interval] = int
+  end
+  opt.parse!
+  config_file, = ARGV
+  d = YAML.load(File.read(config_file))
+  config[:mac_addresses] = d["mac_addresses"]
+end
+
+project_id = config[:project_id]
+dataset = config[:dataset]
+mac_addresses = config[:mac_addresses]
+puts "Project ID: #{project_id}"
+puts "Dataset ID: #{dataset}"
+puts "Monitoring Mac Addresses:"
+config[:mac_addresses].each{|addr| puts "  " + addr }
+
+client = Kura::Client.new(default_project_id: project_id)
+
+measurement_per_raspi_query = <<-EOQ
+SELECT timestamp, w.src_mac AS src_mac, raspi_mac, FLOAT(rssi) AS rssi, room, x, y
+FROM [#{project_id}:#{dataset}.wifi_measurement_time] AS t
+CROSS JOIN
+(SELECT timestamp, raspi_mac, _t.src_mac AS src_mac, rssi
+ FROM [#{project_id}:#{dataset}.wifi_measurement_time] AS _t
+ LEFT JOIN
+ [#{project_id}:#{dataset}.wifi_data] AS _w
+ ON _t.src_mac = _w.src_mac
+) AS w
+WHERE t.start_time <= w.timestamp AND t.finish_time >= w.timestamp AND w.src_mac = t.src_mac
+EOQ
+puts "Run query."
+puts measurement_per_raspi_query
+
+client.query(measurement_per_raspi_query, dataset_id: dataset, table_id: "measurement_data_per_raspi",
+             allow_large_results: true,
+             priority: "INTERACTIVE",
+             mode: :truncate,
+             wait: 300)
+
+table = client.table(dataset, "measurement_data_per_raspi")
+puts "-> #{table.id} (#{table.num_rows} rows)"
+
+measurement_data_query = <<-EOQ
+SELECT
+  t, #{mac_addresses.size.times.map{|i| "MAX(r#{i+1}) as r#{i+1}" }.join(", ")}, room, x, y
+FROM
+#{mac_addresses.map.with_index{|addr, i|
+  q = "  (SELECT INTEGER(timestamp/#{config[:interval]}) AS t, "
+  mac_addresses.size.times.each{|j|
+    if i == j
+      q += "MAX(rssi) AS r#{j+1}, "
+    else
+      q += "NULL AS r#{j+1}, "
+    end
+  }
+  q += "room, x, y\n"
+  q += "FROM [#{project_id}:#{dataset}.measurement_data_per_raspi] WHERE raspi_mac = \"#{addr}\" GROUP BY t, room, x, y)"
+  q
+}.join(",\n")
+}
+GROUP BY t, room, x, y
+ORDER BY room, x, y, t
+EOQ
+
+puts "Run query."
+puts measurement_data_query
+client.query(measurement_data_query, dataset_id: dataset, table_id: "measurement_data",
+             allow_large_results: true,
+             priority: "INTERACTIVE",
+             mode: :truncate,
+             wait: 300)
+
+table = client.table(dataset, "measurement_data")
+puts "-> #{table.id} (#{table.num_rows} rows)"


### PR DESCRIPTION
Add ruby script to run BigQuery queries to create training data from `wifi_data` and `wifi_measurement_time` tables.

1. `cd scripts/generate_training_data`
2. `bundle install --path vendor/bundle`
3. Create config.yml and store monitoring device's MAC addresses. See config.yml.example for reference.
3. `bundle exec ruby create_measurement_data.rb --dataset=DATASET_ID`

- @nakanori 
- @kumanoryo 