### PR TITLE
Do not output tshark root warning message.

### DIFF
--- a/ansible/roles/capture/files/etc/systemd/system/capture.service
+++ b/ansible/roles/capture/files/etc/systemd/system/capture.service
@@ -6,9 +6,12 @@ After=mon-if.service
 EnvironmentFile=/srv/capture/capture.conf
 ExecStart=/srv/capture/capture.sh
 ExecReload=/bin/kill -HUP $MAINPID
-KillMode=process
+ExecStop=/bin/kill $MAINPID
+KillMode=control-group
 Restart=on-failure
 Type=simple
+User=capture
+Group=wireshark
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/capture/files/srv/capture/capture.sh
+++ b/ansible/roles/capture/files/srv/capture/capture.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-tshark -i "${INTERFACE}" -T fields -E separator=',' -e frame.time_epoch -e wlan.sa -e radiotap.dbm_antsignal -b filesize:"${FILE_SIZE_KB}" -b files:"${FILES}" -w "${OUTFILE}" 1>/dev/null
+tshark -i "${INTERFACE}" -T fields -E separator=',' -e frame.time_epoch -e wlan.sa -e radiotap.dbm_antsignal -b filesize:"${FILE_SIZE_KB}" -b files:"${FILES}" -w "${OUTFILE} -g" 1>/dev/null

--- a/ansible/roles/capture/files/srv/capture/capture.sh
+++ b/ansible/roles/capture/files/srv/capture/capture.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-tshark -i "${INTERFACE}" -T fields -E separator=',' -e frame.time_epoch -e wlan.sa -e radiotap.dbm_antsignal -b filesize:"${FILE_SIZE_KB}" -b files:"${FILES}" -w "${OUTFILE} -g" 1>/dev/null
+tshark -i "${INTERFACE}" -T fields -E separator=',' -e frame.time_epoch -e wlan.sa -e radiotap.dbm_antsignal -b filesize:"${FILE_SIZE_KB}" -b files:"${FILES}" -w "${OUTFILE}" -g 1>/dev/null

--- a/ansible/roles/capture/tasks/main.yml
+++ b/ansible/roles/capture/tasks/main.yml
@@ -1,9 +1,42 @@
-- file: path=/srv/capture state=directory owner=root group=root mode=0755
-- file: path=/var/log/capture state=directory owner=root group=root mode=0755
-- copy: src=srv/capture/capture.sh dest=/srv/capture/capture.sh owner=root group=root mode=0755
+- user:
+    name: capture
+    group: capture
+    groups: capture,wireshark
+    shell: /bin/false
+    home: /var/run/capture
+- file: 
+    path: /srv/capture
+    state: directory
+    owner: capture
+    group: capture
+    mode: 0755
+- file:
+    path: /var/log/capture
+    state: directory
+    owner: capture
+    group: wireshark
+    mode: 0775
+- copy:
+    src: srv/capture/capture.sh
+    dest: /srv/capture/capture.sh
+    owner: capture
+    group: capture
+    mode: 0755
   notify: restart capture
-- copy: src=srv/capture/capture.conf dest=/srv/capture/capture.conf owner=root group=root mode=0644
+- copy:
+    src: srv/capture/capture.conf
+    dest: /srv/capture/capture.conf
+    owner: capture
+    group: capture
+    mode: 0644
   notify: restart capture
-- copy: src=etc/systemd/system/capture.service dest=/etc/systemd/system/capture.service owner=root group=root mode=0755
+- copy: 
+    src: etc/systemd/system/capture.service
+    dest: /etc/systemd/system/capture.service
+    owner: root
+    group: root
+    mode: 0644
   notify: restart capture
-- systemd: name=capture enabled=yes
+- systemd:
+    name: capture
+    enabled: yes

--- a/ansible/roles/capture/tasks/main.yml
+++ b/ansible/roles/capture/tasks/main.yml
@@ -1,7 +1,6 @@
 - user:
     name: capture
-    group: capture
-    groups: capture,wireshark
+    groups: wireshark
     shell: /bin/false
     home: /var/run/capture
 - file: 

--- a/ansible/roles/post_data/files/etc/systemd/system/post_data.service
+++ b/ansible/roles/post_data/files/etc/systemd/system/post_data.service
@@ -6,9 +6,11 @@ After=capture.service
 EnvironmentFile=/srv/post_data/post_data.conf
 ExecStart=/srv/post_data/post_data.sh
 ExecReload=/bin/kill -HUP $MAINPID
-KillMode=process
+ExecStop=/bin/kill $MAINPID
+KillMode=control-group
 Restart=on-failure
 Type=simple
+User=post_data
 
 [Install]
 WantedBy=multi-user.target

--- a/ansible/roles/post_data/tasks/main.yml
+++ b/ansible/roles/post_data/tasks/main.yml
@@ -1,7 +1,6 @@
 - user:
     name: post_data
-    group: post_data
-    groups: post_data,wireshark
+    groups: wireshark
     shell: /bin/false
     home: /var/run/post_data
 - file:

--- a/ansible/roles/post_data/tasks/main.yml
+++ b/ansible/roles/post_data/tasks/main.yml
@@ -1,35 +1,41 @@
+- user:
+    name: post_data
+    group: post_data
+    groups: post_data,wireshark
+    shell: /bin/false
+    home: /var/run/post_data
 - file:
     path: /srv/post_data
     state: directory
-    owner: root
-    group: root
+    owner: post_data
+    group: post_data
     mode: 0755
 - copy:
     src: srv/post_data/post_data.sh
     dest: /srv/post_data/post_data.sh
-    owner: root
-    group: root
+    owner: post_data
+    group: post_data
     mode: 0755
   notify: restart post_data
 - copy:
     src: srv/post_data/post_data.conf
     dest: /srv/post_data/post_data.conf
-    owner: root
-    group: root
+    owner: post_data
+    group: post_data
     mode: 0644
   notify: restart post_data
 - template:
     src: srv/post_data/config.yaml.j2
     dest: /srv/post_data/config.yaml
-    owner: root
-    group: root
+    owner: post_data
+    group: post_data
     mode: 0644
   notify: restart post_data
 - copy:
     src: srv/post_data/post_data.py
     dest: /srv/post_data/post_data.py
-    owner: root
-    group: root
+    owner: post_data
+    group: post_data
     mode: 0644
   notify: restart post_data
 - copy:
@@ -37,7 +43,7 @@
     dest: /etc/systemd/system/post_data.service
     owner: root
     group: root
-    mode: 0755
+    mode: 0644
   notify: restart post_data
 - systemd:
     name: post_data

--- a/ansible/roles/tshark/tasks/main.yml
+++ b/ansible/roles/tshark/tasks/main.yml
@@ -16,5 +16,5 @@
     capability: "{{ item.capability }}"
     state: present
   with_items:
-    - { capability: 'cap_net_raw' }
-    - { capability: 'cap_net_admin=eip' }
+    - { capability: 'cap_net_raw+eip' }
+    - { capability: 'cap_net_admin+eip' }

--- a/ansible/roles/tshark/tasks/main.yml
+++ b/ansible/roles/tshark/tasks/main.yml
@@ -13,7 +13,8 @@
     mode: 4750
 - capabilities:
     path: /usr/bin/dumpcap
-    capability:
-      - cap_net_raw
-      - cap_net_admin=eip
+    capability: "{{ item.capability }}"
     state: present
+  with_items:
+    - { capability: 'cap_net_raw' }
+    - { capability: 'cap_net_admin=eip' }

--- a/ansible/roles/tshark/tasks/main.yml
+++ b/ansible/roles/tshark/tasks/main.yml
@@ -10,7 +10,7 @@
 - file:
     path: /usr/bin/dumpcap
     group: wireshark
-    mode: 0750
+    mode: 4750
 - capabilities:
     path: /usr/bin/dumpcap
     capability:

--- a/ansible/roles/tshark/tasks/main.yml
+++ b/ansible/roles/tshark/tasks/main.yml
@@ -4,3 +4,16 @@
     path: /usr/share/wireshark/init.lua
     regexp: '^disable_lua ='
     line: 'disable_lua = true'
+- group:
+    name: wireshark
+    state: present
+- file:
+    path: /usr/bin/dumpcap
+    group: wireshark
+    mode: 0750
+- capabilities:
+    path: /usr/bin/dumpcap
+    capability:
+      - cap_net_raw
+      - cap_net_admin=eip
+    state: present


### PR DESCRIPTION
Do not output this message for /var/log/syslog and systemd journal file.

## capture
```
capture.sh[852]: Running as user "root" and group "root". This could be dangerous.
```

## post_data
```
post_data.sh[2968]: Running as user "root" and group "root". This could be dangerous.
```

- Add group `wireshark`
- Add user `capture` and `post_data` are invited `wireshark` group.
- Change execute user root to `capture` or `post_data`.
- Change /usr/bin/dumpcap file.
  - Change mode 0755 to 4755
  - Change group root to `wireshark`.
  - Add capability `cap_net_raw` and `cap_net_admin=eip`.
  - Because need to execute `capture` and `post_data` user. (ref:[Wireshark wiki](https://wiki.wireshark.org/CaptureSetup/CapturePrivileges))
- Add stop command and change kill mode for capture and post_data.