### PR TITLE
Get send records for MAGELLAN BLOCKS from post_data.

### DIFF
--- a/ansible/roles/zabbix-agent/files/etc/zabbix/scripts/get_send_records.sh
+++ b/ansible/roles/zabbix-agent/files/etc/zabbix/scripts/get_send_records.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+RESULTS_FILE=/var/log/syslog
+TARGET_DATE=$(date -d '1 minute ago' "+ %-d %H:%M:")
+
+send_records=$(grep "${TARGET_DATE}" "${RESULTS_FILE}" | grep "SUCCESS" | awk '{sum+=$9}END{print sum}') || exit 1
+if [ -z "${send_records}" ]
+then
+	send_records=0
+fi
+
+echo "${send_records}"
+
+exit 0

--- a/ansible/roles/zabbix-agent/files/etc/zabbix/zabbix_agentd.conf.d/get_send_records.conf
+++ b/ansible/roles/zabbix-agent/files/etc/zabbix/zabbix_agentd.conf.d/get_send_records.conf
@@ -1,0 +1,1 @@
+UserParameter=gn.send.records,/bin/bash /etc/zabbix/scripts/get_send_records.sh

--- a/ansible/roles/zabbix-agent/tasks/main.yml
+++ b/ansible/roles/zabbix-agent/tasks/main.yml
@@ -1,5 +1,8 @@
 - apt:
     name: zabbix-agent
+- user:
+    name: zabbix
+    groups: zabbix,adm
 - lineinfile:
     dest: /etc/zabbix/zabbix_agentd.conf
     regexp: "^Server="


### PR DESCRIPTION
- Modify user groups for zabbix user. (Add adm group)
  - Because need to syslog file.
- Add zabbix user parameter file.
- Add  script file to get send records count.
