### PR TITLE
Support ignore mac addrs in predict container.

### DIFF
--- a/dataflow/predict-gke/predict.rb
+++ b/dataflow/predict-gke/predict.rb
@@ -58,7 +58,7 @@ module ML
   end
 end
 
-def main(project, input_subscription, raspi_table, room_classifier, position_inferers, bq_dataset, bq_table)
+def main(project, input_subscription, raspi_table, room_classifier, position_inferers, bq_dataset, bq_table, ignore_list)
   $stdout.puts "PubSub:#{input_subscription} -> ML Engine -> BigQuery [#{project}:#{bq_dataset}.#{bq_table}]"
   pubsub = Pubsub.new
   bq = Kura::Client.new
@@ -69,7 +69,9 @@ def main(project, input_subscription, raspi_table, room_classifier, position_inf
     next if msgs.empty?
     st = Time.now
     data = msgs.map{|m| JSON.parse(m.message.data) rescue nil }.compact
-    instances = data.map do |m|
+    instances = data.reject{|m|
+      ignore_list.include?(m["mac_addr"])
+    }.map do |m|
       rssi = raspi_table.map{|n| ((m["rssi"][n] || -100.0) + 100.0) / 50.0 }
       combine = rssi.combination(2).map{|a, b| b.to_f != 0.0 ? a.to_f / b.to_f : 0.0 }
       {
@@ -77,32 +79,34 @@ def main(project, input_subscription, raspi_table, room_classifier, position_inf
         "rssi" => rssi + combine,
       }
     end
-    room_labels = ML.predict(project, room_classifier, instances)
-    results = {}
-    rooms = {}
-    instances.each do|ins|
-      r = room_labels.find{|pred| pred["key"] == ins["key"] }
-      window_timestamp, timestamp, mac = ins["key"].split("_", 3)
-      results[ins["key"]] = {
-        "timestamp" => timestamp.to_i,
-        "window_timestamp" => window_timestamp.to_i,
-        "mac_addr" => mac,
-        "room" => r["label"],
-        "monitored_ap_count" => ins["rssi"][0, raspi_table.size].count{|sig| sig != 0.0 },
-      }
-      if position_inferers.include?(r["label"].to_s)
-        rooms[r["label"]] ||= []
-        rooms[r["label"]] << ins
+    if data.size > 0
+      room_labels = ML.predict(project, room_classifier, instances)
+      results = {}
+      rooms = {}
+      instances.each do|ins|
+        r = room_labels.find{|pred| pred["key"] == ins["key"] }
+        window_timestamp, timestamp, mac = ins["key"].split("_", 3)
+        results[ins["key"]] = {
+          "timestamp" => timestamp.to_i,
+          "window_timestamp" => window_timestamp.to_i,
+          "mac_addr" => mac,
+          "room" => r["label"],
+          "monitored_ap_count" => ins["rssi"][0, raspi_table.size].count{|sig| sig != 0.0 },
+        }
+        if position_inferers.include?(r["label"].to_s)
+          rooms[r["label"]] ||= []
+          rooms[r["label"]] << ins
+        end
       end
-    end
-    rooms.each do |room_no, ins|
-      positions = ML.predict(project, position_inferers[room_no.to_s], ins)
-      positions.each do |pos|
-        results[pos["key"]]["x"] = pos["output"][0]
-        results[pos["key"]]["y"] = pos["output"][1]
+      rooms.each do |room_no, ins|
+        positions = ML.predict(project, position_inferers[room_no.to_s], ins)
+        positions.each do |pos|
+          results[pos["key"]]["x"] = pos["output"][0]
+          results[pos["key"]]["y"] = pos["output"][1]
+        end
       end
+      bq.insert_tabledata(bq_dataset, bq_table, results.values)
     end
-    bq.insert_tabledata(bq_dataset, bq_table, results.values)
     pubsub.ack(input_subscription, msgs)
     ed = Time.now
     $stdout.puts "#{ed - st} seconds to process #{msgs.size} messages."
@@ -120,6 +124,7 @@ if config
   position_inferers = config["position_inferers"]
   bq_dataset = config["bigquery_dataset"]
   bq_table = config["bigquery_table"]
+  ignore_list = config["ignore_mac_addrs"]
 else
   project = ENV["PROJECT"]
   input_subscription = "projects/#{project}/subscriptions/#{ENV["INPUT_SUBSCRIPTION"]}"
@@ -128,8 +133,9 @@ else
   position_inferers = ENV["POSITION_INFERERS"].split(",").each_with_object({}){|i, o| room, name = i.split(":", 2); o[room] = name }
   bq_dataset = ENV["BIGQUERY_DATASET"]
   bq_table = ENV["BIGQUERY_TABLE"]
+  ignore_list = (ENV["IGNORE_MAC_ADDRESSES"] || "").split(",")
 end
 
 $stdout.sync = true
 $stderr.sync = true
-main(project, input_subscription, raspi_table, room_classifier, position_inferers, bq_dataset, bq_table)
+main(project, input_subscription, raspi_table, room_classifier, position_inferers, bq_dataset, bq_table, ignore_list)


### PR DESCRIPTION
Now you can eliminate arbitrary MAC addresses from `predictions` table by specified them via `IGNORE_MAC_ADDRESSES` environment variable.