### PR TITLE
Changed memory settings

### DIFF
--- a/ansible/roles/capture/files/etc/systemd/system/capture.service
+++ b/ansible/roles/capture/files/etc/systemd/system/capture.service
@@ -4,7 +4,10 @@ After=mon-if.service
 
 [Service]
 EnvironmentFile=/srv/capture/capture.conf
-ExecStartPre=/usr/bin/find /var/log/capture/ -type f -delete
+ExecStartPre=+/usr/bin/rm -rf /var/log/capture
+ExecStartPre=+/usr/bin/mkdir /var/log/capture
+ExecStartPre=+/usr/bin/chown capture:wireshark /var/log/capture
+ExecStartPre=+/usr/bin/chmod 775 /var/log/capture
 ExecStart=/srv/capture/capture.sh
 ExecReload=/bin/kill -HUP $MAINPID
 ExecStop=/bin/kill $MAINPID 

--- a/ansible/roles/capture/tasks/main.yml
+++ b/ansible/roles/capture/tasks/main.yml
@@ -9,12 +9,6 @@
     owner: capture
     group: capture
     mode: 0755
-- file:
-    path: /var/log/capture
-    state: directory
-    owner: capture
-    group: wireshark
-    mode: 0775
 - copy:
     src: srv/capture/capture.sh
     dest: /srv/capture/capture.sh

--- a/ansible/roles/rsyslog/files/etc/rsyslog.conf
+++ b/ansible/roles/rsyslog/files/etc/rsyslog.conf
@@ -1,0 +1,92 @@
+# /etc/rsyslog.conf configuration file for rsyslog
+#
+# For more information install rsyslog-doc and see
+# /usr/share/doc/rsyslog-doc/html/configuration/index.html
+
+
+#################
+#### MODULES ####
+#################
+
+module(load="imuxsock") # provides support for local system logging
+module(load="imklog")   # provides kernel logging support
+#module(load="immark")  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+#module(load="imudp")
+#input(type="imudp" port="514")
+
+# provides TCP syslog reception
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner root
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf
+
+
+###############
+#### RULES ####
+###############
+
+#
+# First some standard log files.  Log by facility.
+#
+auth,authpriv.*                 /var/log/auth.log
+*.*;auth,authpriv.none          -/var/log/syslog
+#cron.*                         /var/log/cron.log
+daemon.*                        -/var/log/daemon.log
+# kern.*                          -/var/log/kern.log
+# lpr.*                           -/var/log/lpr.log
+# mail.*                          -/var/log/mail.log
+# user.*                          -/var/log/user.log
+
+#
+# Logging for the mail system.  Split it up so that
+# it is easy to write scripts to parse these files.
+#
+# mail.info                       -/var/log/mail.info
+# mail.warn                       -/var/log/mail.warn
+# mail.err                        /var/log/mail.err
+
+#
+# Some "catch-all" log files.
+#
+# *.=debug;\
+#         auth,authpriv.none;\
+#         news.none;mail.none     -/var/log/debug
+*.=info;*.=notice;*.=warn;\
+        auth,authpriv.none;\
+        cron,daemon.none;\
+        mail,news.none          -/var/log/messages
+
+#
+# Emergencies are sent to everybody logged in.
+#
+*.emerg                         :omusrmsg:*

--- a/ansible/roles/rsyslog/tasks/main.yml
+++ b/ansible/roles/rsyslog/tasks/main.yml
@@ -1,0 +1,6 @@
+- copy:
+    src: etc/rsyslog.conf
+    dest: /etc/rsyslog.conf
+    owner: root
+    group: root
+    mode: 0644

--- a/ansible/roles/swap/tasks/main.yml
+++ b/ansible/roles/swap/tasks/main.yml
@@ -1,0 +1,12 @@
+- shell: swapon -v
+  register: swap_state
+  check_mode: false
+  changed_when: false
+
+- shell: swapoff -a
+  when: swap_state.stdout != ''
+
+- systemd:
+    name: dphys-swapfile
+    enabled: no
+    state: stopped

--- a/ansible/roles/tmpfs/tasks/main.yml
+++ b/ansible/roles/tmpfs/tasks/main.yml
@@ -1,0 +1,18 @@
+- mount:
+    path: /tmp
+    src: tmpfs
+    fstype: tmpfs
+    opts: defaults,size=32m,noatime,mode=1777
+    state: present
+- mount:
+    path: /var/tmp
+    src: tmpfs
+    fstype: tmpfs
+    opts: defaults,size=16m,noatime,mode=1777
+    state: present
+- mount:
+    path: /var/log
+    src: tmpfs
+    fstype: tmpfs
+    opts: defaults,size=64m,noatime,mode=0755
+    state: present

--- a/ansible/site.yml
+++ b/ansible/site.yml
@@ -2,6 +2,9 @@
   hosts: all
   become: yes
   roles:
+    - swap
+    - rsyslog
+    - tmpfs
     - python-apt
     - mon-if
     - tshark


### PR DESCRIPTION
Configured to extend the life of the SD card used in the Raspberry pi.
  
1. Disable swap space on SD card.
```console
$ free -h
              total        used        free      shared  buff/cache   available
Mem:          924Mi       112Mi       598Mi       6.0Mi       213Mi       753Mi
Swap:            0B          0B          0B
```
  
2. Change directories that are frequently written to, such as the /var/log directory, to tmpfs.
```console
$ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root        29G  3.1G   25G  12% /
devtmpfs        430M     0  430M   0% /dev
tmpfs           463M     0  463M   0% /dev/shm
tmpfs           463M  6.3M  456M   2% /run
tmpfs           5.0M  4.0K  5.0M   1% /run/lock
tmpfs           463M     0  463M   0% /sys/fs/cgroup
tmpfs            16M     0   16M   0% /var/tmp
tmpfs            64M  460K   64M   1% /var/log
tmpfs            32M     0   32M   0% /tmp
/dev/mmcblk0p1  253M   49M  204M  20% /boot
```
